### PR TITLE
Fix missing

### DIFF
--- a/articles/azure-functions/functions-reference-python.md
+++ b/articles/azure-functions/functions-reference-python.md
@@ -149,7 +149,7 @@ def main(req: func.HttpRequest,
     logging.info(f'Python HTTP triggered function processed: {obj.read()}')
 ```
 
-İşlev çağrıldığında, HTTP isteği olarak işleve geçirilir `req`. Bir giriş temel Azure Blob depolama alanından alınan _id_ yönlendirme URL'sindeki ve olarak kullanıma sunulan `obj` işlev gövdesindeki.
+İşlev çağrıldığında HTTP isteği 'req' olarak işleve geçirilir. Azure Blob Depolama Alanından, yönlendirme URL'sindeki kimliğe göre bir giriş alınır ve işlev gövdesinde 'obj' olarak kullanıma sunulur.
 
 ## <a name="outputs"></a>Çıkışlar
 

--- a/articles/azure-functions/functions-reference-python.md
+++ b/articles/azure-functions/functions-reference-python.md
@@ -149,7 +149,7 @@ def main(req: func.HttpRequest,
     logging.info(f'Python HTTP triggered function processed: {obj.read()}')
 ```
 
-İşlev çağrıldığında, HTTP isteği olarak işleve geçirilir `req`. Bir giriş temel Azure Blob depolama alanından alınan _kimliği_ yönlendirme URL'sindeki ve olarak kullanıma sunulan `obj` işlev gövdesindeki.
+İşlev çağrıldığında, HTTP isteği olarak işleve geçirilir `req`. Bir giriş temel Azure Blob depolama alanından alınan _id_ yönlendirme URL'sindeki ve olarak kullanıma sunulan `obj` işlev gövdesindeki.
 
 ## <a name="outputs"></a>Çıkışlar
 


### PR DESCRIPTION
Because `id` is a variable name ( `"route ":" items/{id}"`), it is incorrect to translate it.